### PR TITLE
rrhost should not have a dot subfix

### DIFF
--- a/namesilo_ddns.sh
+++ b/namesilo_ddns.sh
@@ -5,6 +5,7 @@ DOMAIN="mydomain.tld"
 
 ##Host name (subdomain). Optional. If present, must end with a dot (.)
 HOST="subdomain."
+HOST_RAW=$(echo $HOST |sed 's/\.[^.]*$//')
 
 ##APIKEY obtained from Namesilo:
 APIKEY="c40031261ee449037a4b4"
@@ -61,7 +62,7 @@ if [ "$CUR_IP" != "$KNOWN_IP" ]; then
   ##Update DNS record in Namesilo:
   curl -s "https://www.namesilo.com/api/dnsListRecords?version=1&type=xml&key=$APIKEY&domain=$DOMAIN" > $DOMAIN.xml 
   RECORD_ID=`xmllint --xpath "//namesilo/reply/resource_record/record_id[../host/text() = '$HOST$DOMAIN' ]" $DOMAIN.xml | grep -oP '(?<=<record_id>).*?(?=</record_id>)'`
-  curl -s "https://www.namesilo.com/api/dnsUpdateRecord?version=1&type=xml&key=$APIKEY&domain=$DOMAIN&rrid=$RECORD_ID&rrhost=$HOST&rrvalue=$CUR_IP&rrttl=3600" > $RESPONSE
+  curl -s "https://www.namesilo.com/api/dnsUpdateRecord?version=1&type=xml&key=$APIKEY&domain=$DOMAIN&rrid=$RECORD_ID&rrhost=$HOST_RAW&rrvalue=$CUR_IP&rrttl=3600" > $RESPONSE
     RESPONSE_CODE=`xmllint --xpath "//namesilo/reply/code/text()"  $RESPONSE`
        case $RESPONSE_CODE in
        300)


### PR DESCRIPTION

rrhost should not have a dot subfix, otherwise namesilo will report domain not found.

the error response will looks like below

<namesilo><request><operation>dnsUpdateRecord</operation><ip>121.228.14.21</ip></request><reply><code>280</code><detail>subdomain..domain.me is not a valid host</detail></reply></namesilo>